### PR TITLE
Avoid `Accept` header override

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -162,7 +162,9 @@ function setApiUri(options) {
 function setRequestHeaders(options) {
     let headers = options.headers || {};
     headers = mergeJSON(headers, {"Content-Type": "application/json"});
-    headers = mergeJSON(headers, {"Accept": "application/json"});
+    if (! headers['Accept']) {
+        headers = mergeJSON(headers, {"Accept": "application/json"});
+    }
     options.headers = headers;
     return options;
 }


### PR DESCRIPTION
We are working on an implementation that downloads a `PaymentReceipt` from QuickBooks.

This endpoint requires the header "Accept" with "application/pdf" value. Currently, the package is overriding the value with "application/json".

The fix on this branch allows the user to send a custom explicit "Accept" header. If it is not present it will fallback to the default value as it is working right now.

Reference: https://developer.intuit.com/app/developer/qbpayments/docs/api/resources/all-entities/paymentreceipt#get-a-payment-receipt