### PR TITLE
Implement `DELETE` http requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This is the URL webhooks can be sent. You need to configure this URL in the webh
 
 ## HTTP requests
 
-You can make `GET` and `POST` requests to the [QuickBooks API](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/account) like this:
+You can make `GET`, `POST`, and `DELETE` requests to the [QuickBooks API](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/account) like this:
 
 ```js
 let startPosition = 1;
@@ -104,6 +104,15 @@ let response = pkg.quickbooks.api.post({
  path: '/invoice',
  params: { operation: existingQbInvoice ? 'update' : 'create' },
  body: requestBody
+});
+```
+
+```js
+let response = pkg.quickbooks.api.delete({
+  path: `/customers/${customerId}/cards/${cardId}`,
+  headers: {
+    'request-Id': requestId
+  }
 });
 ```
 

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -6,7 +6,8 @@ let httpReference = dependencies.http;
 
 let httpDependency = {
     get: httpReference.get,
-    post: httpReference.post
+    post: httpReference.post,
+    delete: httpReference.delete,
 };
 
 let httpService = {};
@@ -72,6 +73,20 @@ exports.get = function(path, httpOptions, callbackData, callbacks) {
 exports.post = function(path, httpOptions, callbackData, callbacks) {
     let options = checkHttpOptions(path, httpOptions);
     return httpService.post(Quickbooks(options), callbackData, callbacks);
+};
+
+/**
+ * Sends an HTTP DELETE request to the specified URL with the provided HTTP options.
+ *
+ * @param {string} path         - The path to send the DELETE request to.
+ * @param {object} httpOptions  - The options to be included in the DELETE request check http-service documentation.
+ * @param {object} callbackData - Additional data to be passed to the callback functions. [optional]
+ * @param {object} callbacks    - The callback functions to be called upon completion of the DELETE request. [optional]
+ * @return {object}             - The response of the DELETE request.
+ */
+exports.delete = function(path, httpOptions, callbackData, callbacks) {
+    let options = checkHttpOptions(path, httpOptions);
+    return httpService.delete(Quickbooks(options), callbackData, callbacks);
 };
 
 /****************************************************


### PR DESCRIPTION
I am working on an implementation that requires removing a card from a specific customer.

It uses the "DELETE" HTTP method. I just added a copy from the other GET and POST helpers.

QuickBooks Reference: https://developer.intuit.com/app/developer/qbpayments/docs/api/resources/all-entities/cards#delete-a-card

