### PR TITLE
Adjust minor version to `75`

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
             "name": "minorVersion",
             "label": "Minor Version",
             "description": "The QuickBooks Online API supports minor versions in order to provide a way for you to access incremental changes without breaking existing apps.",
-            "defaultValue": 69,
+            "defaultValue": 75,
             "type": "text",
             "typeOptions": {
                 "validation": "number"


### PR DESCRIPTION
QuickBooks is stopping support for minor versions between 1 and 74:

https://blogs.intuit.com/2025/01/21/changes-to-our-accounting-api-that-may-impact-your-application/

I think it would be better to have Default minor version on 75 from now on to avoid external issues with QuickBooks.